### PR TITLE
test: pipeline validation — add VM labels

### DIFF
--- a/.github/workflows/_tf-core.yml
+++ b/.github/workflows/_tf-core.yml
@@ -37,7 +37,7 @@ jobs:
     name: "Check for changes"
     runs-on: ubuntu-latest
     outputs:
-      has_changes: ${{ steps.changed.outputs.any_changed }}
+      has_changes: ${{ steps.detect.outputs.has_changes }}
 
     steps:
       - uses: actions/checkout@v4
@@ -45,22 +45,31 @@ jobs:
           fetch-depth: 0
 
       - name: "Detect changed infra files"
-        id: changed
-        uses: tj-actions/changed-files@v46
-        with:
-          files_yaml: |
-            any:
-              - 'modules/**'
-              - 'regions/${{ inputs.region }}/${{ inputs.environment }}/**'
-              - 'root.hcl'
-              - '.github/workflows/_tf-core.yml'
-
-      - name: "Report"
+        id: detect
         run: |
-          echo "has_changes=${{ steps.changed.outputs.any_changed }}"
-          echo "always_plan=${{ inputs.always_plan }}"
-          if [ "${{ steps.changed.outputs.any_changed }}" = "false" ] && [ "${{ inputs.always_plan }}" = "false" ]; then
-            echo "::notice::No infra files changed — skipping plan/apply."
+          # PR event: compare head against base branch
+          # Push event: compare against previous commit
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="origin/${{ github.base_ref }}"
+            CHANGED=$(git diff --name-only "${BASE}...HEAD" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+          else
+            CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          if echo "$CHANGED" | grep -qE \
+            "^(modules/|regions/${{ inputs.region }}/${{ inputs.environment }}/|root\.hcl|\.github/workflows/_tf-core\.yml)"; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Infra changes detected — running plan."
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            if [ "${{ inputs.always_plan }}" = "true" ]; then
+              echo "::notice::No infra changes but always_plan=true — running plan anyway."
+            else
+              echo "::notice::No infra files changed — skipping plan/apply."
+            fi
           fi
 
 # ── Job 2: Discover — find all stacks ─────────────────────────────────────────

--- a/.github/workflows/_tf-core.yml
+++ b/.github/workflows/_tf-core.yml
@@ -251,11 +251,37 @@ jobs:
             TABLE+="| \`${MOD}\` | ${ICON} | ${ADDS} | ${CHGS} | ${DEST} |"$'\n'
 
             if [ -f "$OUT" ]; then
-              DIFF=$(grep -E "^\s+(#|~|\+|-)\s" "$OUT" | head -20 || true)
+              # Parse resource-level changes from Terragrunt output.
+              # Terragrunt prefixes lines: "STDERR terraform:   # resource.addr will be created"
+              RESOURCE_TABLE=""
+              while IFS= read -r line; do
+                if echo "$line" | grep -qE "# .* will be (created|updated|destroyed|replaced|modified)|must be replaced"; then
+                  ADDR=$(echo "$line" | grep -oP '(?<=# )[\w.\[\]"_-]+')
+                  if echo "$line" | grep -q "will be created";               then ACT="**+** create"
+                  elif echo "$line" | grep -q "will be updated\|will be modified"; then ACT="**~** update"
+                  elif echo "$line" | grep -q "will be destroyed";           then ACT="**-** destroy"
+                  elif echo "$line" | grep -q "must be replaced";            then ACT="**±** replace"
+                  else ACT="**?** change"; fi
+                  RESOURCE_TABLE+="| ${ACT} | \`${ADDR}\` |"$'\n'
+                fi
+              done < "$OUT"
+
               FULL=$(tail -c 5000 "$OUT")
-              DETAILS+="<details><summary><b>${MOD}</b> -- ${ICON}</summary>"$'\n\n'
-              [ -n "$DIFF" ] && DETAILS+="**Changed resources:**"$'\n''```hcl'$'\n'"${DIFF}"$'\n''```'$'\n\n'
-              DETAILS+='```hcl'$'\n'"${FULL}"$'\n''```'$'\n'"</details>"$'\n\n'
+
+              DETAILS+="<details>"$'\n'
+              DETAILS+="<summary><b>${MOD}</b> &nbsp;—&nbsp; ${ICON} &nbsp;(+${ADDS} ~${CHGS} -${DEST})</summary>"$'\n\n'
+
+              if [ -n "$RESOURCE_TABLE" ]; then
+                DETAILS+="| Action | Resource |"$'\n'
+                DETAILS+="|--------|----------|"$'\n'
+                DETAILS+="${RESOURCE_TABLE}"$'\n'
+              fi
+
+              DETAILS+="<details>"$'\n'
+              DETAILS+="<summary>Full plan output</summary>"$'\n\n'
+              DETAILS+='```hcl'$'\n'"${FULL}"$'\n''```'$'\n'
+              DETAILS+="</details>"$'\n'
+              DETAILS+="</details>"$'\n\n'
             fi
           done
 

--- a/.github/workflows/_tf-core.yml
+++ b/.github/workflows/_tf-core.yml
@@ -153,7 +153,7 @@ jobs:
           terragrunt plan --terragrunt-non-interactive -no-color 2>&1 \
             | tee /tmp/plan-output.txt || EXIT=$?
 
-          PLAN_LINE=$(grep -E "^Plan:|No changes\." /tmp/plan-output.txt | tail -1 || true)
+          PLAN_LINE=$(grep -E "Plan: [0-9]|No changes\." /tmp/plan-output.txt | tail -1 || true)
 
           if [ "$EXIT" -eq 1 ]; then
             STATUS="error"; ADDS=0; CHGS=0; DEST=0; HAS_CHANGES=false

--- a/modules/compute-vm/main.tf
+++ b/modules/compute-vm/main.tf
@@ -34,6 +34,11 @@ resource "google_compute_instance" "api" {
   # Tags must match firewall target_tags
   tags = ["allow-iap-ssh", "sweptlock-backend"]
 
+  labels = {
+    managed-by  = "terraform"
+    environment = var.name_prefix
+  }
+
   boot_disk {
     initialize_params {
       image = "debian-cloud/debian-12"


### PR DESCRIPTION
Testing the new Terraform pipeline end-to-end.

## What this tests
- Changed-files check detects `modules/compute-vm/main.tf`
- Plan runs for all modules (compute shows 1 change, others show no changes)
- Per-module parallel jobs appear in GitHub Actions UI
- PR comment posted with plan table + resource diff
- Summarize posts expected: compute = change (label), everything else = no changes

## Change
Adds `managed-by` and `environment` labels to the compute VM instance.
Labels are metadata only — no resource recreation, no downtime.