### PR TITLE
feat(ci): folder-based env detection, single approval gate, tf-setup composite action

### DIFF
--- a/.github/actions/tf-setup/action.yml
+++ b/.github/actions/tf-setup/action.yml
@@ -1,0 +1,41 @@
+name: "TF Setup"
+description: "Install Terraform, Terragrunt, and authenticate to GCP via WIF"
+
+inputs:
+  service-account:
+    description: "GCP service account email to impersonate"
+    required: true
+  wif-provider:
+    description: "Workload Identity Federation provider URI"
+    required: true
+  project-id:
+    description: "GCP project ID"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: "Install Terraform"
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: "1.9.8"
+        terraform_wrapper: false
+
+    - name: "Install Terragrunt"
+      shell: bash
+      run: |
+        VER=$(cat .terragrunt-version 2>/dev/null || echo "0.67.16")
+        curl -sSL "https://github.com/gruntwork-io/terragrunt/releases/download/v${VER}/terragrunt_linux_amd64" \
+          -o /usr/local/bin/terragrunt
+        chmod +x /usr/local/bin/terragrunt
+
+    - name: "Authenticate to GCP"
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ inputs.wif-provider }}
+        service_account: ${{ inputs.service-account }}
+
+    - name: "Setup gcloud"
+      uses: google-github-actions/setup-gcloud@v2
+      with:
+        project_id: ${{ inputs.project-id }}

--- a/.github/workflows/_tf-core.yml
+++ b/.github/workflows/_tf-core.yml
@@ -1,21 +1,29 @@
 name: "TF Core (reusable)"
-# Never triggered directly — called by tf-plan.yml and tf-apply.yml.
+# Never triggered directly — called by tf-plan.yml (PR) and tf-apply.yml (merge).
 #
-# Flow when action=plan:   check → (skip if no changes) → discover → plan (parallel) → summarize
-# Flow when action=apply:  check → (skip if no changes) → discover → plan (parallel) → summarize → approve → apply → post-result
+# Single-environment model:
+#   - Plan/summarize jobs do NOT bind to a GitHub Environment.
+#     They use repo-level secrets (WIF_PROVIDER, SA_CI_TF_PLAN_EMAIL).
+#     Plan SA has read-only / low blast radius.
+#   - Apply job binds to `environment: ${{ inputs.environment }}`.
+#     The environment's required-reviewers list IS the approval gate.
+#     Apply SA (SA_CI_TF_APPLY_EMAIL) lives as an environment secret.
+#   - No separate approve job — environment binding is the gate.
 #
-# Adopted from friend's pipeline: changed-files check, skip-if-no-changes, continue-on-error on
-# plan (artifacts saved even on failure), apply-only-if-changes gate, apply result PR comment.
+# Environments are folders under regions/<region>/<env>/, not git branches.
+# Both plan and apply auto-detect affected envs in the parent workflow.
+# project_id is resolved here per env name — single source of truth.
 #
-# GitHub Environments required per real env (e.g. "sandbox"):
-#   sandbox        — secrets: WIF_PROVIDER, SA_CI_TF_PLAN_EMAIL, SA_CI_TF_APPLY_EMAIL (no reviewers)
-#   sandbox-apply  — required reviewers (no secrets — approval gate only)
+# Required secrets:
+#   Repo:                                  WIF_PROVIDER, SA_CI_TF_PLAN_EMAIL
+#   Env (sandbox / staging / prod):        SA_CI_TF_APPLY_EMAIL
+#                                          + required reviewers under environment protection rules
 
 on:
   workflow_call:
     inputs:
       environment:
-        description: "Target environment — must match folder under regions/<region>/"
+        description: "Target env — must match folder under regions/<region>/"
         type: string
         required: true
       region:
@@ -26,61 +34,40 @@ on:
         description: "plan or apply"
         type: string
         default: "plan"
-      always_plan:
-        description: "Force plan even if no infra files changed (useful for debugging)"
-        type: boolean
-        default: false
 
-# ── Job 1: Check — skip pipeline if no infra files changed ────────────────────
+env:
+  TF_INPUT: "false"
+  TF_IN_AUTOMATION: "true"
+
 jobs:
-  check:
-    name: "Check for changes"
+  # ── 1. setup — resolve project_id from environment name ───────────────────
+  setup:
+    name: "Resolve project"
     runs-on: ubuntu-latest
     outputs:
-      has_changes: ${{ steps.detect.outputs.has_changes }}
-
+      project_id: ${{ steps.resolve.outputs.project_id }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: "Detect changed infra files"
-        id: detect
+      - name: "Resolve GCP project for env"
+        id: resolve
         run: |
-          # PR event: compare head against base branch
-          # Push event: compare against previous commit
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="origin/${{ github.base_ref }}"
-            CHANGED=$(git diff --name-only "${BASE}...HEAD" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
-          else
-            CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
-          fi
+          case "${{ inputs.environment }}" in
+            sandbox) PROJECT="cryptoshare-e5172" ;;
+            staging) PROJECT="sweptlock-staging" ;;
+            prod)    PROJECT="sweptlock-prod" ;;
+            *)
+              echo "::error::Unknown environment '${{ inputs.environment }}' — add a case here when adding a new env"
+              exit 1 ;;
+          esac
+          echo "project_id=$PROJECT" >> "$GITHUB_OUTPUT"
+          echo "env=${{ inputs.environment }} region=${{ inputs.region }} project=$PROJECT"
 
-          echo "Changed files:"
-          echo "$CHANGED"
-
-          if echo "$CHANGED" | grep -qE \
-            "^(modules/|regions/${{ inputs.region }}/${{ inputs.environment }}/|root\.hcl|\.github/workflows/_tf-core\.yml)"; then
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Infra changes detected — running plan."
-          else
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            if [ "${{ inputs.always_plan }}" = "true" ]; then
-              echo "::notice::No infra changes but always_plan=true — running plan anyway."
-            else
-              echo "::notice::No infra files changed — skipping plan/apply."
-            fi
-          fi
-
-# ── Job 2: Discover — find all stacks ─────────────────────────────────────────
+  # ── 2. discover — list terragrunt stacks for this env ─────────────────────
   discover:
     name: "Discover stacks"
-    needs: [check]
-    if: needs.check.outputs.has_changes == 'true' || inputs.always_plan
+    needs: [setup]
     runs-on: ubuntu-latest
     outputs:
       modules: ${{ steps.find.outputs.modules }}
-
     steps:
       - uses: actions/checkout@v4
 
@@ -89,7 +76,7 @@ jobs:
         run: |
           DIR="regions/${{ inputs.region }}/${{ inputs.environment }}"
           if [ ! -d "$DIR" ]; then
-            echo "::error::$DIR not found — check environment and region inputs"
+            echo "::error::$DIR not found — env folder does not exist"
             exit 1
           fi
           MODULES=$(find "$DIR" \
@@ -102,12 +89,12 @@ jobs:
           echo "modules=$MODULES" >> "$GITHUB_OUTPUT"
           echo "Discovered: $MODULES"
 
-# ── Job 3: Plan — parallel matrix, one job per module ─────────────────────────
+  # ── 3. plan — parallel matrix, one job per module ─────────────────────────
+  # No `environment:` binding. Uses repo-level secrets (plan SA).
   plan:
     name: "Plan — ${{ matrix.module }}"
-    needs: [discover]
+    needs: [setup, discover]
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
       matrix:
@@ -115,35 +102,16 @@ jobs:
     permissions:
       contents: read
       id-token: write
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Install Terraform"
-        uses: hashicorp/setup-terraform@v3
+      - name: "Setup Terraform + Terragrunt + GCP auth"
+        uses: ./.github/actions/tf-setup
         with:
-          terraform_version: "1.9.8"
-          terraform_wrapper: false
+          service-account: ${{ secrets.SA_CI_TF_PLAN_EMAIL }}
+          wif-provider: ${{ secrets.WIF_PROVIDER }}
+          project-id: ${{ needs.setup.outputs.project_id }}
 
-      - name: "Install Terragrunt"
-        run: |
-          VER=$(cat .terragrunt-version 2>/dev/null || echo "0.67.16")
-          curl -sSL "https://github.com/gruntwork-io/terragrunt/releases/download/v${VER}/terragrunt_linux_amd64" \
-            -o /usr/local/bin/terragrunt
-          chmod +x /usr/local/bin/terragrunt
-
-      - name: "Authenticate to GCP"
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.SA_CI_TF_PLAN_EMAIL }}
-
-      - name: "Setup gcloud"
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: ${{ env.PROJECT_ID }}
-
-      # continue-on-error so artifact is always uploaded even when plan fails
       - name: "Plan ${{ matrix.module }}"
         id: plan
         working-directory: "regions/${{ inputs.region }}/${{ inputs.environment }}/${{ matrix.module }}"
@@ -153,21 +121,19 @@ jobs:
           terragrunt plan --terragrunt-non-interactive -no-color 2>&1 \
             | tee /tmp/plan-output.txt || EXIT=$?
 
+          # Terragrunt prefixes lines with timestamps — match anywhere on the line.
           PLAN_LINE=$(grep -E "Plan: [0-9]|No changes\." /tmp/plan-output.txt | tail -1 || true)
 
           if [ "$EXIT" -eq 1 ]; then
-            STATUS="error"; ADDS=0; CHGS=0; DEST=0; HAS_CHANGES=false
+            STATUS="error"; ADDS=0; CHGS=0; DEST=0
           elif [[ "$PLAN_LINE" == *"No changes"* ]] || [[ -z "$PLAN_LINE" ]]; then
-            STATUS="no-changes"; ADDS=0; CHGS=0; DEST=0; HAS_CHANGES=false
+            STATUS="no-changes"; ADDS=0; CHGS=0; DEST=0
           else
             ADDS=$(echo "$PLAN_LINE" | grep -oP '\d+(?= to add)'     | head -1 || echo 0)
             CHGS=$(echo "$PLAN_LINE" | grep -oP '\d+(?= to change)'  | head -1 || echo 0)
             DEST=$(echo "$PLAN_LINE" | grep -oP '\d+(?= to destroy)' | head -1 || echo 0)
-            HAS_CHANGES=true
             if [ "${DEST:-0}" -gt 0 ]; then STATUS="destroys"; else STATUS="changes"; fi
           fi
-
-          echo "has_changes=$HAS_CHANGES" >> "$GITHUB_OUTPUT"
 
           mkdir -p /tmp/artifact
           cp /tmp/plan-output.txt /tmp/artifact/output.txt
@@ -178,37 +144,35 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: "plan-${{ matrix.module }}"
+          name: "plan-${{ inputs.environment }}-${{ matrix.module }}"
           path: /tmp/artifact/
           retention-days: 3
           if-no-files-found: warn
 
-      # Explicit fail after artifact upload — mirrors friend's continue-on-error pattern
       - name: "Fail if plan errored"
         if: steps.plan.outcome == 'failure'
         run: |
           echo "::error::Plan failed for ${{ matrix.module }}"
           exit 1
 
-# ── Job 4: Summarize — build PR comment + job summary ─────────────────────────
+  # ── 4. summarize — build PR comment + run summary ─────────────────────────
   summarize:
     name: "Summarize"
     needs: [discover, plan]
     if: always() && needs.discover.result == 'success'
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
     outputs:
       has_changes: ${{ steps.build.outputs.has_changes }}
+      has_destroys: ${{ steps.build.outputs.has_destroys }}
     permissions:
       pull-requests: write
-
     steps:
       - uses: actions/checkout@v4
 
       - name: "Download plan artifacts"
         uses: actions/download-artifact@v4
         with:
-          pattern: "plan-*"
+          pattern: "plan-${{ inputs.environment }}-*"
           path: /tmp/plans
           merge-multiple: false
 
@@ -216,15 +180,16 @@ jobs:
         id: build
         run: |
           MODULES='${{ needs.discover.outputs.modules }}'
-          OVERALL="No changes"
+          OVERALL_ICON="✅"
+          OVERALL_TEXT="No changes"
           HAS_CHANGES=false
           HAS_DESTROYS=false
           TABLE=""
           DETAILS=""
 
           for MOD in $(echo "$MODULES" | jq -r '.[]'); do
-            META="/tmp/plans/plan-${MOD}/meta.txt"
-            OUT="/tmp/plans/plan-${MOD}/output.txt"
+            META="/tmp/plans/plan-${{ inputs.environment }}-${MOD}/meta.txt"
+            OUT="/tmp/plans/plan-${{ inputs.environment }}-${MOD}/output.txt"
 
             if [ -f "$META" ]; then
               STATUS=$(sed -n '1p' "$META")
@@ -234,34 +199,40 @@ jobs:
 
               case "$STATUS" in
                 error)
-                  ICON="Error"; OVERALL="Plan failed" ;;
+                  ICON="❌ Error"
+                  OVERALL_ICON="❌"; OVERALL_TEXT="Plan failed" ;;
                 no-changes)
-                  ICON="No changes" ;;
+                  ICON="✅ No changes" ;;
                 destroys)
-                  ICON="Destroys"; HAS_CHANGES=true; HAS_DESTROYS=true
-                  [ "$OVERALL" != "Plan failed" ] && OVERALL="Destroys planned" ;;
+                  ICON="⚠️ Destroys"
+                  HAS_CHANGES=true; HAS_DESTROYS=true
+                  if [ "$OVERALL_TEXT" != "Plan failed" ]; then
+                    OVERALL_ICON="⚠️"; OVERALL_TEXT="Destroys planned"
+                  fi ;;
                 changes)
-                  ICON="Changes"; HAS_CHANGES=true
-                  [ "$OVERALL" == "No changes" ] && OVERALL="Changes pending" ;;
+                  ICON="📋 Changes"
+                  HAS_CHANGES=true
+                  if [ "$OVERALL_TEXT" = "No changes" ]; then
+                    OVERALL_ICON="📋"; OVERALL_TEXT="Changes pending"
+                  fi ;;
               esac
             else
-              ICON="Skipped"; ADDS="-"; CHGS="-"; DEST="-"
+              ICON="⏭️ Skipped"; ADDS="-"; CHGS="-"; DEST="-"
             fi
 
             TABLE+="| \`${MOD}\` | ${ICON} | ${ADDS} | ${CHGS} | ${DEST} |"$'\n'
 
             if [ -f "$OUT" ]; then
-              # Parse resource-level changes from Terragrunt output.
-              # Terragrunt prefixes lines: "STDERR terraform:   # resource.addr will be created"
+              # Per-resource action table — strip Terragrunt timestamp prefix when matching.
               RESOURCE_TABLE=""
               while IFS= read -r line; do
                 if echo "$line" | grep -qE "# .* will be (created|updated|destroyed|replaced|modified)|must be replaced"; then
                   ADDR=$(echo "$line" | grep -oP '(?<=# )[\w.\[\]"_-]+')
-                  if echo "$line" | grep -q "will be created";               then ACT="**+** create"
-                  elif echo "$line" | grep -q "will be updated\|will be modified"; then ACT="**~** update"
-                  elif echo "$line" | grep -q "will be destroyed";           then ACT="**-** destroy"
-                  elif echo "$line" | grep -q "must be replaced";            then ACT="**±** replace"
-                  else ACT="**?** change"; fi
+                  if   echo "$line" | grep -q "will be created";                       then ACT="\`+\` create"
+                  elif echo "$line" | grep -qE "will be (updated|modified)";           then ACT="\`~\` update"
+                  elif echo "$line" | grep -q "will be destroyed";                     then ACT="\`-\` destroy"
+                  elif echo "$line" | grep -qE "(must be replaced|will be replaced)";  then ACT="\`±\` replace"
+                  else ACT="\`?\` change"; fi
                   RESOURCE_TABLE+="| ${ACT} | \`${ADDR}\` |"$'\n'
                 fi
               done < "$OUT"
@@ -270,15 +241,12 @@ jobs:
 
               DETAILS+="<details>"$'\n'
               DETAILS+="<summary><b>${MOD}</b> &nbsp;—&nbsp; ${ICON} &nbsp;(+${ADDS} ~${CHGS} -${DEST})</summary>"$'\n\n'
-
               if [ -n "$RESOURCE_TABLE" ]; then
                 DETAILS+="| Action | Resource |"$'\n'
                 DETAILS+="|--------|----------|"$'\n'
                 DETAILS+="${RESOURCE_TABLE}"$'\n'
               fi
-
-              DETAILS+="<details>"$'\n'
-              DETAILS+="<summary>Full plan output</summary>"$'\n\n'
+              DETAILS+="<details><summary>Full plan output</summary>"$'\n\n'
               DETAILS+='```hcl'$'\n'"${FULL}"$'\n''```'$'\n'
               DETAILS+="</details>"$'\n'
               DETAILS+="</details>"$'\n\n'
@@ -286,20 +254,22 @@ jobs:
           done
 
           WARN=""
-          [ "$HAS_DESTROYS" = "true" ] && WARN=$'\n'"**WARNING: This plan destroys resources. Review carefully before approving.**"$'\n'
+          [ "$HAS_DESTROYS" = "true" ] && WARN=$'\n'"> ⚠️ **This plan destroys resources. Review carefully before approving the apply.**"$'\n'
 
           NEXT_STEP=""
           if [ "${{ inputs.action }}" = "apply" ] && [ "$HAS_CHANGES" = "true" ]; then
             NEXT_STEP=$'\n'"---"$'\n'"**Next:** approve this run in the [GitHub Actions UI](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) to apply."
           elif [ "$HAS_CHANGES" = "false" ]; then
-            NEXT_STEP=$'\n'"**No infrastructure changes — apply will be skipped.**"
+            NEXT_STEP=$'\n'"_No infrastructure changes — apply will be skipped._"
           fi
 
           SHA="${GITHUB_SHA::7}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ACTION_TITLE=$(echo "${{ inputs.action }}" | sed 's/./\U&/')
 
           {
-            printf "## Terraform %s -- \`%s\` (\`%s\`)\n\n" "${{ inputs.action }}" "${{ inputs.environment }}" "${{ inputs.region }}"
+            printf "## %s Terraform %s — \`%s\` (\`%s\`)\n\n" "$OVERALL_ICON" "$ACTION_TITLE" "${{ inputs.environment }}" "${{ inputs.region }}"
+            printf "**Overall:** %s %s\n\n" "$OVERALL_ICON" "$OVERALL_TEXT"
             printf "Commit: [\`%s\`](%s/commit/%s) | @%s | [Run #%s](%s)\n\n" \
               "$SHA" "${{ github.server_url }}/${{ github.repository }}" "${{ github.sha }}" \
               "${{ github.actor }}" "${{ github.run_number }}" "$RUN_URL"
@@ -312,15 +282,20 @@ jobs:
           } > /tmp/summary.md
 
           echo "has_changes=$HAS_CHANGES" >> "$GITHUB_OUTPUT"
+          echo "has_destroys=$HAS_DESTROYS" >> "$GITHUB_OUTPUT"
           cat /tmp/summary.md >> "$GITHUB_STEP_SUMMARY"
 
+      # PR comment — only on PR events. Sticky marker is per-env so multi-env PRs don't overwrite each other.
       - name: "Post or update PR comment"
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          ENV_NAME: ${{ inputs.environment }}
         with:
           script: |
             const fs = require('fs');
-            const marker = '<!-- tf-plan-sweptlock -->';
+            const env = process.env.ENV_NAME;
+            const marker = `<!-- tf-plan-sweptlock:${env} -->`;
             const body = marker + '\n' + fs.readFileSync('/tmp/summary.md', 'utf8');
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo,
@@ -339,69 +314,35 @@ jobs:
               });
             }
 
-# ── Job 5: Approve — human reviews plan and approves here ─────────────────────
-# Only runs when action=apply AND there are actual changes to apply.
-# "sandbox-apply" environment must have required reviewers configured.
-  approve:
-    name: "Approve apply"
-    needs: [summarize]
-    if: |
-      inputs.action == 'apply' &&
-      needs.summarize.outputs.has_changes == 'true'
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}-apply
-
-    steps:
-      - name: "Plan approved"
-        run: |
-          echo "Apply approved by: ${{ github.actor }}"
-          echo "Environment: ${{ inputs.environment }} (${{ inputs.region }})"
-
-# ── Job 6: Apply — safety-checked apply using approved plan metadata ───────────
+  # ── 5. apply — environment-gated, runs only on action=apply with changes ──
+  # `environment: ${{ inputs.environment }}` is the approval gate.
+  # Skipped (no reviewer prompt) when there are no changes.
   apply:
     name: "Apply"
-    needs: [discover, approve]
+    needs: [setup, discover, summarize]
     if: |
       inputs.action == 'apply' &&
-      needs.approve.result == 'success'
+      needs.summarize.result == 'success' &&
+      needs.summarize.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
       contents: read
       id-token: write
-      pull-requests: write
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Install Terraform"
-        uses: hashicorp/setup-terraform@v3
+      - name: "Setup Terraform + Terragrunt + GCP auth"
+        uses: ./.github/actions/tf-setup
         with:
-          terraform_version: "1.9.8"
-          terraform_wrapper: false
-
-      - name: "Install Terragrunt"
-        run: |
-          VER=$(cat .terragrunt-version 2>/dev/null || echo "0.67.16")
-          curl -sSL "https://github.com/gruntwork-io/terragrunt/releases/download/v${VER}/terragrunt_linux_amd64" \
-            -o /usr/local/bin/terragrunt
-          chmod +x /usr/local/bin/terragrunt
-
-      - name: "Authenticate to GCP"
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.SA_CI_TF_APPLY_EMAIL }}
-
-      - name: "Setup gcloud"
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: ${{ env.PROJECT_ID }}
+          service-account: ${{ secrets.SA_CI_TF_APPLY_EMAIL }}
+          wif-provider: ${{ secrets.WIF_PROVIDER }}
+          project-id: ${{ needs.setup.outputs.project_id }}
 
       - name: "Download approved plan metadata"
         uses: actions/download-artifact@v4
         with:
-          pattern: "plan-*"
+          pattern: "plan-${{ inputs.environment }}-*"
           path: /tmp/approved-plans
           merge-multiple: false
 
@@ -412,12 +353,11 @@ jobs:
           BLOCKED=false
 
           for MOD in $(echo "$MODULES" | jq -r '.[]'); do
-            META="/tmp/approved-plans/plan-${MOD}/meta.txt"
+            META="/tmp/approved-plans/plan-${{ inputs.environment }}-${MOD}/meta.txt"
             APPROVED_DEST=0
             [ -f "$META" ] && APPROVED_DEST=$(sed -n '4p' "$META" || echo 0)
 
-            CURRENT_OUT=$(cd "./${MOD}" && terragrunt plan \
-              --terragrunt-non-interactive -no-color 2>&1 || true)
+            CURRENT_OUT=$(cd "./${MOD}" && terragrunt plan --terragrunt-non-interactive -no-color 2>&1 || true)
             CURRENT_DEST=$(echo "$CURRENT_OUT" | grep -oP '\d+(?= to destroy)' | head -1 || echo 0)
 
             if [ "${CURRENT_DEST:-0}" -gt "${APPROVED_DEST:-0}" ]; then
@@ -435,9 +375,8 @@ jobs:
         working-directory: "regions/${{ inputs.region }}/${{ inputs.environment }}"
         continue-on-error: true
         run: |
-          terragrunt run --all apply \
-            --terragrunt-non-interactive \
-            -auto-approve 2>&1 | tee /tmp/apply-output.txt
+          terragrunt run --all apply --terragrunt-non-interactive -auto-approve 2>&1 \
+            | tee /tmp/apply-output.txt
 
       - name: "Write apply summary"
         if: always()
@@ -447,7 +386,7 @@ jobs:
           [ "$STATUS" != "success" ] && ICON="❌"
 
           {
-            printf "## %s Terraform Apply -- \`%s\`\n\n" "$ICON" "${{ inputs.environment }}"
+            printf "## %s Terraform Apply — \`%s\`\n\n" "$ICON" "${{ inputs.environment }}"
             printf "| | |\n|---|---|\n"
             printf "| Status | %s |\n" "$STATUS"
             printf "| Commit | \`%s\` |\n" "${GITHUB_SHA::7}"
@@ -463,52 +402,6 @@ jobs:
 
           cat /tmp/apply-summary.md >> "$GITHUB_STEP_SUMMARY"
 
-      # Post apply result back to PR — mirrors friend's pattern of keeping PR as the audit trail
-      - name: "Post apply result to PR"
-        if: github.event_name == 'pull_request' || github.event_name == 'push'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const marker = '<!-- tf-apply-sweptlock -->';
-            const summary = fs.readFileSync('/tmp/apply-summary.md', 'utf8');
-            const body = marker + '\n' + summary;
-
-            // Find the PR associated with this commit (for push events)
-            let issueNumber = context.issue?.number;
-            if (!issueNumber && context.eventName === 'push') {
-              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                owner: context.repo.owner, repo: context.repo.repo,
-                commit_sha: context.sha,
-              });
-              if (prs.length > 0) issueNumber = prs[0].number;
-            }
-
-            if (!issueNumber) {
-              console.log('No PR found for this commit — skipping comment');
-              return;
-            }
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: issueNumber,
-            });
-            const existing = comments.find(c => c.body.startsWith(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                comment_id: existing.id, body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: issueNumber, body,
-              });
-            }
-
       - name: "Fail if apply errored"
         if: steps.apply.outcome == 'failure'
         run: exit 1
-
-env:
-  PROJECT_ID: "cryptoshare-e5172"

--- a/.github/workflows/_tf-core.yml
+++ b/.github/workflows/_tf-core.yml
@@ -37,7 +37,7 @@ jobs:
     name: "Check for changes"
     runs-on: ubuntu-latest
     outputs:
-      has_changes: ${{ steps.changed.outputs.any_changed }}
+      has_changes: ${{ steps.detect.outputs.has_changes }}
 
     steps:
       - uses: actions/checkout@v4
@@ -45,22 +45,31 @@ jobs:
           fetch-depth: 0
 
       - name: "Detect changed infra files"
-        id: changed
-        uses: tj-actions/changed-files@v46
-        with:
-          files_yaml: |
-            any:
-              - 'modules/**'
-              - 'regions/${{ inputs.region }}/${{ inputs.environment }}/**'
-              - 'root.hcl'
-              - '.github/workflows/_tf-core.yml'
-
-      - name: "Report"
+        id: detect
         run: |
-          echo "has_changes=${{ steps.changed.outputs.any_changed }}"
-          echo "always_plan=${{ inputs.always_plan }}"
-          if [ "${{ steps.changed.outputs.any_changed }}" = "false" ] && [ "${{ inputs.always_plan }}" = "false" ]; then
-            echo "::notice::No infra files changed — skipping plan/apply."
+          # PR event: compare head against base branch
+          # Push event: compare against previous commit
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="origin/${{ github.base_ref }}"
+            CHANGED=$(git diff --name-only "${BASE}...HEAD" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+          else
+            CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          if echo "$CHANGED" | grep -qE \
+            "^(modules/|regions/${{ inputs.region }}/${{ inputs.environment }}/|root\.hcl|\.github/workflows/_tf-core\.yml)"; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Infra changes detected — running plan."
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            if [ "${{ inputs.always_plan }}" = "true" ]; then
+              echo "::notice::No infra changes but always_plan=true — running plan anyway."
+            else
+              echo "::notice::No infra files changed — skipping plan/apply."
+            fi
           fi
 
 # ── Job 2: Discover — find all stacks ─────────────────────────────────────────

--- a/.github/workflows/_tf-core.yml
+++ b/.github/workflows/_tf-core.yml
@@ -251,11 +251,37 @@ jobs:
             TABLE+="| \`${MOD}\` | ${ICON} | ${ADDS} | ${CHGS} | ${DEST} |"$'\n'
 
             if [ -f "$OUT" ]; then
-              DIFF=$(grep -E "^\s+(#|~|\+|-)\s" "$OUT" | head -20 || true)
+              # Parse resource-level changes from Terragrunt output.
+              # Terragrunt prefixes lines: "STDERR terraform:   # resource.addr will be created"
+              RESOURCE_TABLE=""
+              while IFS= read -r line; do
+                if echo "$line" | grep -qE "# .* will be (created|updated|destroyed|replaced|modified)|must be replaced"; then
+                  ADDR=$(echo "$line" | grep -oP '(?<=# )[\w.\[\]"_-]+')
+                  if echo "$line" | grep -q "will be created";               then ACT="**+** create"
+                  elif echo "$line" | grep -q "will be updated\|will be modified"; then ACT="**~** update"
+                  elif echo "$line" | grep -q "will be destroyed";           then ACT="**-** destroy"
+                  elif echo "$line" | grep -q "must be replaced";            then ACT="**±** replace"
+                  else ACT="**?** change"; fi
+                  RESOURCE_TABLE+="| ${ACT} | \`${ADDR}\` |"$'\n'
+                fi
+              done < "$OUT"
+
               FULL=$(tail -c 5000 "$OUT")
-              DETAILS+="<details><summary><b>${MOD}</b> -- ${ICON}</summary>"$'\n\n'
-              [ -n "$DIFF" ] && DETAILS+="**Changed resources:**"$'\n''```hcl'$'\n'"${DIFF}"$'\n''```'$'\n\n'
-              DETAILS+='```hcl'$'\n'"${FULL}"$'\n''```'$'\n'"</details>"$'\n\n'
+
+              DETAILS+="<details>"$'\n'
+              DETAILS+="<summary><b>${MOD}</b> &nbsp;—&nbsp; ${ICON} &nbsp;(+${ADDS} ~${CHGS} -${DEST})</summary>"$'\n\n'
+
+              if [ -n "$RESOURCE_TABLE" ]; then
+                DETAILS+="| Action | Resource |"$'\n'
+                DETAILS+="|--------|----------|"$'\n'
+                DETAILS+="${RESOURCE_TABLE}"$'\n'
+              fi
+
+              DETAILS+="<details>"$'\n'
+              DETAILS+="<summary>Full plan output</summary>"$'\n\n'
+              DETAILS+='```hcl'$'\n'"${FULL}"$'\n''```'$'\n'
+              DETAILS+="</details>"$'\n'
+              DETAILS+="</details>"$'\n\n'
             fi
           done
 

--- a/.github/workflows/_tf-core.yml
+++ b/.github/workflows/_tf-core.yml
@@ -187,6 +187,48 @@ jobs:
           TABLE=""
           DETAILS=""
 
+          # Write plan parser once. Strips ANSI codes + Terragrunt timestamp/level prefix,
+          # then splits the plan output into one <details> block per resource.
+          cat > /tmp/parse_plan.py << 'PYEOF'
+          import sys, re
+          with open(sys.argv[1]) as f:
+              raw = f.read()
+          # Strip ANSI colour codes
+          clean = re.sub(r'\x1b\[[0-9;]*m', '', raw)
+          # Strip Terragrunt prefix: "HH:MM:SS.mmm LEVEL word: "
+          clean = re.sub(r'^\d{2}:\d{2}:\d{2}\.\d+\s+\S+\s+\S+\s+', '', clean, flags=re.MULTILINE)
+          lines = clean.split('\n')
+          blocks = []
+          cur_addr = cur_action = None
+          cur_lines = []
+          for line in lines:
+              m = re.match(r'\s+#\s+(\S+)\s+will be (\w+)', line)
+              if m:
+                  if cur_addr:
+                      blocks.append((cur_addr, cur_action, list(cur_lines)))
+                  cur_addr = m.group(1)
+                  w = m.group(2)
+                  cur_action = '+' if w == 'created' else '~' if w in ('updated','modified') else '-' if w == 'destroyed' else '±' if w == 'replaced' else '?'
+                  cur_lines = [line]
+              elif cur_addr is not None:
+                  if re.match(r'\s*(Plan:|No changes\.)', line):
+                      break
+                  cur_lines.append(line)
+          if cur_addr:
+              blocks.append((cur_addr, cur_action, list(cur_lines)))
+          for addr, action, blines in blocks:
+              block = '\n'.join(blines).strip()
+              print(f'<details>')
+              print(f'<summary><code>{action} {addr}</code></summary>')
+              print()
+              print('```hcl')
+              print(block)
+              print('```')
+              print()
+              print('</details>')
+              print()
+          PYEOF
+
           for MOD in $(echo "$MODULES" | jq -r '.[]'); do
             META="/tmp/plans/plan-${{ inputs.environment }}-${MOD}/meta.txt"
             OUT="/tmp/plans/plan-${{ inputs.environment }}-${MOD}/output.txt"
@@ -223,32 +265,10 @@ jobs:
             TABLE+="| \`${MOD}\` | ${ICON} | ${ADDS} | ${CHGS} | ${DEST} |"$'\n'
 
             if [ -f "$OUT" ]; then
-              # Per-resource action table — strip Terragrunt timestamp prefix when matching.
-              RESOURCE_TABLE=""
-              while IFS= read -r line; do
-                if echo "$line" | grep -qE "# .* will be (created|updated|destroyed|replaced|modified)|must be replaced"; then
-                  ADDR=$(echo "$line" | grep -oP '(?<=# )[\w.\[\]"_-]+')
-                  if   echo "$line" | grep -q "will be created";                       then ACT="\`+\` create"
-                  elif echo "$line" | grep -qE "will be (updated|modified)";           then ACT="\`~\` update"
-                  elif echo "$line" | grep -q "will be destroyed";                     then ACT="\`-\` destroy"
-                  elif echo "$line" | grep -qE "(must be replaced|will be replaced)";  then ACT="\`±\` replace"
-                  else ACT="\`?\` change"; fi
-                  RESOURCE_TABLE+="| ${ACT} | \`${ADDR}\` |"$'\n'
-                fi
-              done < "$OUT"
-
-              FULL=$(tail -c 5000 "$OUT")
-
+              RESOURCE_DETAILS=$(python3 /tmp/parse_plan.py "$OUT")
               DETAILS+="<details>"$'\n'
               DETAILS+="<summary><b>${MOD}</b> &nbsp;—&nbsp; ${ICON} &nbsp;(+${ADDS} ~${CHGS} -${DEST})</summary>"$'\n\n'
-              if [ -n "$RESOURCE_TABLE" ]; then
-                DETAILS+="| Action | Resource |"$'\n'
-                DETAILS+="|--------|----------|"$'\n'
-                DETAILS+="${RESOURCE_TABLE}"$'\n'
-              fi
-              DETAILS+="<details><summary>Full plan output</summary>"$'\n\n'
-              DETAILS+='```hcl'$'\n'"${FULL}"$'\n''```'$'\n'
-              DETAILS+="</details>"$'\n'
+              DETAILS+="${RESOURCE_DETAILS}"$'\n'
               DETAILS+="</details>"$'\n\n'
             fi
           done

--- a/.github/workflows/_tf-core.yml
+++ b/.github/workflows/_tf-core.yml
@@ -178,132 +178,152 @@ jobs:
 
       - name: "Build summary"
         id: build
+        env:
+          MODULES: '${{ needs.discover.outputs.modules }}'
+          ENV_NAME: '${{ inputs.environment }}'
+          REGION: '${{ inputs.region }}'
+          ACTION: '${{ inputs.action }}'
+          GH_SHA: '${{ github.sha }}'
+          GH_ACTOR: '${{ github.actor }}'
+          GH_RUN_NUMBER: '${{ github.run_number }}'
+          GH_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          GH_REPO_URL: '${{ github.server_url }}/${{ github.repository }}'
         run: |
-          MODULES='${{ needs.discover.outputs.modules }}'
-          OVERALL_ICON="✅"
-          OVERALL_TEXT="No changes"
-          HAS_CHANGES=false
-          HAS_DESTROYS=false
-          TABLE=""
-          DETAILS=""
+          python3 << 'PYEOF'
+          import json, re, os
 
-          # Write plan parser once. Strips ANSI codes + Terragrunt timestamp/level prefix,
-          # then splits the plan output into one <details> block per resource.
-          cat > /tmp/parse_plan.py << 'PYEOF'
-          import sys, re
-          with open(sys.argv[1]) as f:
-              raw = f.read()
-          # Strip ANSI colour codes
-          clean = re.sub(r'\x1b\[[0-9;]*m', '', raw)
-          # Strip Terragrunt prefix: "HH:MM:SS.mmm LEVEL word: "
-          clean = re.sub(r'^\d{2}:\d{2}:\d{2}\.\d+\s+\S+\s+\S+\s+', '', clean, flags=re.MULTILINE)
-          lines = clean.split('\n')
-          blocks = []
-          cur_addr = cur_action = None
-          cur_lines = []
-          for line in lines:
-              m = re.match(r'\s+#\s+(\S+)\s+will be (\w+)', line)
-              if m:
-                  if cur_addr:
-                      blocks.append((cur_addr, cur_action, list(cur_lines)))
-                  cur_addr = m.group(1)
-                  w = m.group(2)
-                  cur_action = '+' if w == 'created' else '~' if w in ('updated','modified') else '-' if w == 'destroyed' else '±' if w == 'replaced' else '?'
-                  cur_lines = [line]
-              elif cur_addr is not None:
-                  if re.match(r'\s*(Plan:|No changes\.)', line):
-                      break
-                  cur_lines.append(line)
-          if cur_addr:
-              blocks.append((cur_addr, cur_action, list(cur_lines)))
-          for addr, action, blines in blocks:
-              block = '\n'.join(blines).strip()
-              print(f'<details>')
-              print(f'<summary><code>{action} {addr}</code></summary>')
-              print()
-              print('```hcl')
-              print(block)
-              print('```')
-              print()
-              print('</details>')
-              print()
+          modules    = json.loads(os.environ['MODULES'])
+          env        = os.environ['ENV_NAME']
+          region     = os.environ['REGION']
+          action     = os.environ['ACTION']
+          sha        = os.environ['GH_SHA'][:7]
+          actor      = os.environ['GH_ACTOR']
+          run_number = os.environ['GH_RUN_NUMBER']
+          run_url    = os.environ['GH_RUN_URL']
+          repo_url   = os.environ['GH_REPO_URL']
+          full_sha   = os.environ['GH_SHA']
+          plans_dir  = '/tmp/plans'
+          gh_output  = os.environ.get('GITHUB_OUTPUT', '')
+          gh_summary = os.environ.get('GITHUB_STEP_SUMMARY', '')
+
+          def strip_noise(text):
+              text = re.sub(r'\x1b\[[0-9;]*m', '', text)
+              text = re.sub(r'^\d{2}:\d{2}:\d{2}\.\d+\s+\S+\s+\S+\s+', '', text, flags=re.MULTILINE)
+              return text
+
+          def parse_blocks(text):
+              lines = text.split('\n')
+              blocks, cur_addr, cur_action, cur_lines = [], None, None, []
+              for line in lines:
+                  m = re.match(r'\s+#\s+(\S+)\s+will be (\w+)', line)
+                  if m:
+                      if cur_addr:
+                          blocks.append((cur_addr, cur_action, '\n'.join(cur_lines)))
+                      cur_addr = m.group(1)
+                      w = m.group(2)
+                      cur_action = ('+' if w == 'created' else
+                                    '~' if w in ('updated', 'modified') else
+                                    '-' if w == 'destroyed' else
+                                    '±' if w == 'replaced' else '?')
+                      cur_lines = [line]
+                  elif cur_addr is not None:
+                      if re.match(r'\s*(Plan:|No changes\.)', line):
+                          break
+                      cur_lines.append(line)
+              if cur_addr:
+                  blocks.append((cur_addr, cur_action, '\n'.join(cur_lines)))
+              return blocks
+
+          overall_icon, overall_text = '✅', 'No changes'
+          has_changes = has_destroys = False
+          table_rows, module_details = [], []
+
+          for mod in modules:
+              meta_path = f'{plans_dir}/plan-{env}-{mod}/meta.txt'
+              out_path  = f'{plans_dir}/plan-{env}-{mod}/output.txt'
+
+              if os.path.exists(meta_path):
+                  parts  = open(meta_path).read().strip().split('\n')
+                  status = parts[0] if parts else 'error'
+                  adds   = parts[1] if len(parts) > 1 else '0'
+                  chgs   = parts[2] if len(parts) > 2 else '0'
+                  dest   = parts[3] if len(parts) > 3 else '0'
+
+                  if status == 'error':
+                      icon = '❌ Error'
+                      overall_icon, overall_text = '❌', 'Plan failed'
+                  elif status == 'no-changes':
+                      icon = '✅ No changes'
+                  elif status == 'destroys':
+                      icon = '⚠️ Destroys'
+                      has_changes = has_destroys = True
+                      if overall_text != 'Plan failed':
+                          overall_icon, overall_text = '⚠️', 'Destroys planned'
+                  else:
+                      icon = '📋 Changes'
+                      has_changes = True
+                      if overall_text == 'No changes':
+                          overall_icon, overall_text = '📋', 'Changes pending'
+              else:
+                  icon, adds, chgs, dest = '⏭️ Skipped', '-', '-', '-'
+
+              table_rows.append(f'| `{mod}` | {icon} | {adds} | {chgs} | {dest} |')
+
+              if os.path.exists(out_path):
+                  blocks = parse_blocks(strip_noise(open(out_path).read()))
+                  resource_html = ''
+                  for addr, act, block_text in blocks:
+                      resource_html += (
+                          '<details>\n'
+                          f'<summary><code>{act} {addr}</code></summary>\n\n'
+                          '```hcl\n'
+                          f'{block_text.strip()}\n'
+                          '```\n\n'
+                          '</details>\n\n'
+                      )
+                  module_details.append(
+                      '<details>\n'
+                      f'<summary><b>{mod}</b> &nbsp;&mdash;&nbsp; {icon} &nbsp;'
+                      f'(+{adds} ~{chgs} -{dest})</summary>\n\n'
+                      f'{resource_html}'
+                      '</details>\n\n'
+                  )
+
+          warn = ('\n> ⚠️ **This plan destroys resources. Review carefully before approving.**\n'
+                  if has_destroys else '')
+
+          if action == 'apply' and has_changes:
+              next_step = f'\n---\n**Next:** approve this run in the [GitHub Actions UI]({run_url}) to apply.'
+          elif not has_changes:
+              next_step = '\n_No infrastructure changes — apply will be skipped._'
+          else:
+              next_step = ''
+
+          summary = '\n'.join([
+              f'## {overall_icon} Terraform {action.capitalize()} — `{env}` (`{region}`)\n',
+              f'**Overall:** {overall_icon} {overall_text}\n',
+              f'Commit: [`{sha}`]({repo_url}/commit/{full_sha}) | @{actor} | [Run #{run_number}]({run_url})\n',
+              '| Module | Status | Add | Change | Destroy |',
+              '|--------|--------|-----|--------|---------|',
+              '\n'.join(table_rows),
+              warn,
+              '\n### Module Details\n',
+              ''.join(module_details),
+              next_step,
+          ])
+
+          with open('/tmp/summary.md', 'w') as f:
+              f.write(summary)
+
+          if gh_output:
+              with open(gh_output, 'a') as f:
+                  f.write(f'has_changes={"true" if has_changes else "false"}\n')
+                  f.write(f'has_destroys={"true" if has_destroys else "false"}\n')
+
+          if gh_summary:
+              with open(gh_summary, 'a') as f:
+                  f.write(summary)
           PYEOF
-
-          for MOD in $(echo "$MODULES" | jq -r '.[]'); do
-            META="/tmp/plans/plan-${{ inputs.environment }}-${MOD}/meta.txt"
-            OUT="/tmp/plans/plan-${{ inputs.environment }}-${MOD}/output.txt"
-
-            if [ -f "$META" ]; then
-              STATUS=$(sed -n '1p' "$META")
-              ADDS=$(sed -n '2p' "$META")
-              CHGS=$(sed -n '3p' "$META")
-              DEST=$(sed -n '4p' "$META")
-
-              case "$STATUS" in
-                error)
-                  ICON="❌ Error"
-                  OVERALL_ICON="❌"; OVERALL_TEXT="Plan failed" ;;
-                no-changes)
-                  ICON="✅ No changes" ;;
-                destroys)
-                  ICON="⚠️ Destroys"
-                  HAS_CHANGES=true; HAS_DESTROYS=true
-                  if [ "$OVERALL_TEXT" != "Plan failed" ]; then
-                    OVERALL_ICON="⚠️"; OVERALL_TEXT="Destroys planned"
-                  fi ;;
-                changes)
-                  ICON="📋 Changes"
-                  HAS_CHANGES=true
-                  if [ "$OVERALL_TEXT" = "No changes" ]; then
-                    OVERALL_ICON="📋"; OVERALL_TEXT="Changes pending"
-                  fi ;;
-              esac
-            else
-              ICON="⏭️ Skipped"; ADDS="-"; CHGS="-"; DEST="-"
-            fi
-
-            TABLE+="| \`${MOD}\` | ${ICON} | ${ADDS} | ${CHGS} | ${DEST} |"$'\n'
-
-            if [ -f "$OUT" ]; then
-              RESOURCE_DETAILS=$(python3 /tmp/parse_plan.py "$OUT")
-              DETAILS+="<details>"$'\n'
-              DETAILS+="<summary><b>${MOD}</b> &nbsp;—&nbsp; ${ICON} &nbsp;(+${ADDS} ~${CHGS} -${DEST})</summary>"$'\n\n'
-              DETAILS+="${RESOURCE_DETAILS}"$'\n'
-              DETAILS+="</details>"$'\n\n'
-            fi
-          done
-
-          WARN=""
-          [ "$HAS_DESTROYS" = "true" ] && WARN=$'\n'"> ⚠️ **This plan destroys resources. Review carefully before approving the apply.**"$'\n'
-
-          NEXT_STEP=""
-          if [ "${{ inputs.action }}" = "apply" ] && [ "$HAS_CHANGES" = "true" ]; then
-            NEXT_STEP=$'\n'"---"$'\n'"**Next:** approve this run in the [GitHub Actions UI](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) to apply."
-          elif [ "$HAS_CHANGES" = "false" ]; then
-            NEXT_STEP=$'\n'"_No infrastructure changes — apply will be skipped._"
-          fi
-
-          SHA="${GITHUB_SHA::7}"
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          ACTION_TITLE=$(echo "${{ inputs.action }}" | sed 's/./\U&/')
-
-          {
-            printf "## %s Terraform %s — \`%s\` (\`%s\`)\n\n" "$OVERALL_ICON" "$ACTION_TITLE" "${{ inputs.environment }}" "${{ inputs.region }}"
-            printf "**Overall:** %s %s\n\n" "$OVERALL_ICON" "$OVERALL_TEXT"
-            printf "Commit: [\`%s\`](%s/commit/%s) | @%s | [Run #%s](%s)\n\n" \
-              "$SHA" "${{ github.server_url }}/${{ github.repository }}" "${{ github.sha }}" \
-              "${{ github.actor }}" "${{ github.run_number }}" "$RUN_URL"
-            printf "| Module | Status | Add | Change | Destroy |\n"
-            printf "|--------|--------|-----|--------|---------|\n"
-            printf "%s" "$TABLE"
-            printf "%s\n\n" "$WARN"
-            printf "### Module Details\n\n%s" "$DETAILS"
-            printf "%s\n" "$NEXT_STEP"
-          } > /tmp/summary.md
-
-          echo "has_changes=$HAS_CHANGES" >> "$GITHUB_OUTPUT"
-          echo "has_destroys=$HAS_DESTROYS" >> "$GITHUB_OUTPUT"
-          cat /tmp/summary.md >> "$GITHUB_STEP_SUMMARY"
 
       # PR comment — only on PR events. Sticky marker is per-env so multi-env PRs don't overwrite each other.
       - name: "Post or update PR comment"

--- a/.github/workflows/_tf-core.yml
+++ b/.github/workflows/_tf-core.yml
@@ -153,7 +153,7 @@ jobs:
           terragrunt plan --terragrunt-non-interactive -no-color 2>&1 \
             | tee /tmp/plan-output.txt || EXIT=$?
 
-          PLAN_LINE=$(grep -E "^Plan:|No changes\." /tmp/plan-output.txt | tail -1 || true)
+          PLAN_LINE=$(grep -E "Plan: [0-9]|No changes\." /tmp/plan-output.txt | tail -1 || true)
 
           if [ "$EXIT" -eq 1 ]; then
             STATUS="error"; ADDS=0; CHGS=0; DEST=0; HAS_CHANGES=false

--- a/.github/workflows/_tf-core.yml
+++ b/.github/workflows/_tf-core.yml
@@ -212,10 +212,11 @@ jobs:
               return text
 
           def parse_blocks(text):
+              # Use re.search so leading-space count after prefix-strip doesn't matter.
               lines = text.split('\n')
               blocks, cur_addr, cur_action, cur_lines = [], None, None, []
               for line in lines:
-                  m = re.match(r'\s+#\s+(\S+)\s+will be (\w+)', line)
+                  m = re.search(r'#\s+(\S+)\s+will be (\w+)', line)
                   if m:
                       if cur_addr:
                           blocks.append((cur_addr, cur_action, '\n'.join(cur_lines)))
@@ -227,7 +228,7 @@ jobs:
                                     '±' if w == 'replaced' else '?')
                       cur_lines = [line]
                   elif cur_addr is not None:
-                      if re.match(r'\s*(Plan:|No changes\.)', line):
+                      if 'Plan:' in line or 'No changes.' in line:
                           break
                       cur_lines.append(line)
               if cur_addr:
@@ -270,7 +271,8 @@ jobs:
               table_rows.append(f'| `{mod}` | {icon} | {adds} | {chgs} | {dest} |')
 
               if os.path.exists(out_path):
-                  blocks = parse_blocks(strip_noise(open(out_path).read()))
+                  clean_text = strip_noise(open(out_path).read())
+                  blocks = parse_blocks(clean_text)
                   resource_html = ''
                   for addr, act, block_text in blocks:
                       resource_html += (
@@ -281,6 +283,10 @@ jobs:
                           '```\n\n'
                           '</details>\n\n'
                       )
+                  # Fallback: if block parsing found nothing, show stripped raw output
+                  if not resource_html:
+                      tail = '\n'.join(clean_text.strip().splitlines()[-80:])
+                      resource_html = f'```hcl\n{tail}\n```\n\n'
                   module_details.append(
                       '<details>\n'
                       f'<summary><b>{mod}</b> &nbsp;&mdash;&nbsp; {icon} &nbsp;'

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -1,53 +1,84 @@
 name: "Terraform Apply"
-# Triggered on merge to main/staging/prod — automatically determines environment from branch.
-# Flow: plan → summarize (comment) → approve (reviewer sees plan → approves) → apply (safety-checked)
+# Triggered on merge (push) to main only. Single long-lived branch.
+# Environments are folders, not branches: regions/<region>/<env>/.
 #
-# GitHub Environments required per real environment:
-#   <env>        — secrets: WIF_PROVIDER, SA_CI_TF_PLAN_EMAIL, SA_CI_TF_APPLY_EMAIL
-#   <env>-apply  — required reviewers (no secrets — this is only the approval gate)
+# Detect logic mirrors tf-plan.yml (same git diff against the previous commit on main).
+# For each affected env, calls _tf-core which:
+#   1. plans the env (artifacts uploaded)
+#   2. summarizes (has_changes signal)
+#   3. apply step runs ONLY if has_changes == true AND env reviewers approve
+#      (the env's GitHub Environment is the approval gate — separate per env)
 
 on:
   push:
-    branches: [main, staging, prod]
+    branches: [main]
     paths:
       - "modules/**"
       - "regions/**"
       - "root.hcl"
+      - ".github/workflows/tf-apply.yml"
+      - ".github/workflows/_tf-core.yml"
+      - ".github/actions/tf-setup/**"
 
 concurrency:
   group: tf-apply-${{ github.ref_name }}
-  cancel-in-progress: false  # never cancel an in-progress apply
+  cancel-in-progress: false   # never cancel an in-progress apply
 
 jobs:
-  # Determine environment from the branch that was pushed to — no user input needed
-  setup:
-    name: "Determine environment"
+  detect:
+    name: "Detect changed environments"
     runs-on: ubuntu-latest
     outputs:
-      environment: ${{ steps.resolve.outputs.environment }}
-      region:      ${{ steps.resolve.outputs.region }}
+      envs: ${{ steps.detect.outputs.envs }}
+      region: ${{ steps.detect.outputs.region }}
     steps:
-      - name: "Resolve env from branch"
-        id: resolve
-        run: |
-          case "${{ github.ref_name }}" in
-            prod)    ENV="prod";    REGION="me-west1" ;;
-            staging) ENV="staging"; REGION="me-west1" ;;
-            *)       ENV="sandbox"; REGION="me-west1" ;;
-          esac
-          echo "environment=$ENV"  >> "$GITHUB_OUTPUT"
-          echo "region=$REGION"    >> "$GITHUB_OUTPUT"
-          echo "Resolved: env=$ENV region=$REGION (branch=${{ github.ref_name }})"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2   # need previous commit to diff against
 
-  core:
-    needs: [setup]
+      - name: "Detect"
+        id: detect
+        run: |
+          REGION="me-west1"
+          CHANGED=$(git diff --name-only HEAD~1 HEAD)
+
+          echo "Changed files:"
+          echo "$CHANGED"
+          echo ""
+
+          # Shared changes affect every environment — apply them all.
+          SHARED_RX="^(modules/|root\.hcl|\.github/workflows/_tf-core\.yml|\.github/actions/tf-setup/)"
+          if echo "$CHANGED" | grep -qE "$SHARED_RX"; then
+            ENVS=$(find "regions/$REGION" -maxdepth 1 -mindepth 1 -type d \
+              -not -name "_*" \
+              -printf "%f\n" 2>/dev/null \
+              | sort | jq -R . | jq -sc .)
+            echo "::notice::Shared infra change — applying all envs: $ENVS"
+          else
+            ENVS=$(echo "$CHANGED" \
+              | grep -oP "^regions/$REGION/\K[^/]+" \
+              | sort -u | jq -R . | jq -sc .)
+            echo "::notice::Per-env change detected: $ENVS"
+          fi
+
+          [ -z "$ENVS" ] || [ "$ENVS" = "null" ] && ENVS="[]"
+          echo "envs=$ENVS" >> "$GITHUB_OUTPUT"
+          echo "region=$REGION" >> "$GITHUB_OUTPUT"
+
+  apply:
+    name: "Apply ${{ matrix.env }}"
+    needs: [detect]
+    if: needs.detect.outputs.envs != '[]'
     permissions:
       contents: read
       id-token: write
-      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        env: ${{ fromJson(needs.detect.outputs.envs) }}
     uses: ./.github/workflows/_tf-core.yml
     with:
-      environment: ${{ needs.setup.outputs.environment }}
-      region:      ${{ needs.setup.outputs.region }}
+      environment: ${{ matrix.env }}
+      region:      ${{ needs.detect.outputs.region }}
       action:      apply
     secrets: inherit

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -1,52 +1,83 @@
 name: "Terraform Plan"
-# Runs on PRs — plan only, no apply.
-# Posts per-module plan results as a PR comment for review.
-# Use tf-apply.yml to apply after review.
+# Triggered on PRs to main only. Single long-lived branch.
+# Environments are folders, not branches: regions/<region>/<env>/.
+#
+# Detects which env folders the PR touches, then matrix-calls _tf-core
+# once per affected env. Shared changes (modules/, root.hcl, workflow files)
+# trigger plans for ALL existing env folders.
 
 on:
   pull_request:
-    branches: [main, staging, prod]
+    branches: [main]
     paths:
       - "modules/**"
       - "regions/**"
       - "root.hcl"
       - ".github/workflows/tf-plan.yml"
       - ".github/workflows/_tf-core.yml"
+      - ".github/actions/tf-setup/**"
 
 concurrency:
   group: tf-plan-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:
-  # Determine environment from the PR target branch — no user input needed
-  setup:
-    name: "Determine environment"
+  detect:
+    name: "Detect changed environments"
     runs-on: ubuntu-latest
     outputs:
-      environment: ${{ steps.resolve.outputs.environment }}
-      region:      ${{ steps.resolve.outputs.region }}
+      envs: ${{ steps.detect.outputs.envs }}
+      region: ${{ steps.detect.outputs.region }}
     steps:
-      - name: "Resolve env from target branch"
-        id: resolve
-        run: |
-          case "${{ github.base_ref }}" in
-            prod)    ENV="prod";    REGION="me-west1" ;;
-            staging) ENV="staging"; REGION="me-west1" ;;
-            *)       ENV="sandbox"; REGION="me-west1" ;;
-          esac
-          echo "environment=$ENV"  >> "$GITHUB_OUTPUT"
-          echo "region=$REGION"    >> "$GITHUB_OUTPUT"
-          echo "Resolved: env=$ENV region=$REGION"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  core:
-    needs: [setup]
+      - name: "Detect"
+        id: detect
+        run: |
+          REGION="me-west1"
+          BASE="origin/${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only "${BASE}...HEAD" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+
+          echo "Changed files:"
+          echo "$CHANGED"
+          echo ""
+
+          # Shared changes affect every environment — plan them all.
+          SHARED_RX="^(modules/|root\.hcl|\.github/workflows/_tf-core\.yml|\.github/actions/tf-setup/)"
+          if echo "$CHANGED" | grep -qE "$SHARED_RX"; then
+            ENVS=$(find "regions/$REGION" -maxdepth 1 -mindepth 1 -type d \
+              -not -name "_*" \
+              -printf "%f\n" 2>/dev/null \
+              | sort | jq -R . | jq -sc .)
+            echo "::notice::Shared infra change — planning all envs: $ENVS"
+          else
+            ENVS=$(echo "$CHANGED" \
+              | grep -oP "^regions/$REGION/\K[^/]+" \
+              | sort -u | jq -R . | jq -sc .)
+            echo "::notice::Per-env change detected: $ENVS"
+          fi
+
+          [ -z "$ENVS" ] || [ "$ENVS" = "null" ] && ENVS="[]"
+          echo "envs=$ENVS" >> "$GITHUB_OUTPUT"
+          echo "region=$REGION" >> "$GITHUB_OUTPUT"
+
+  plan:
+    name: "Plan ${{ matrix.env }}"
+    needs: [detect]
+    if: needs.detect.outputs.envs != '[]'
     permissions:
       contents: read
       id-token: write
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        env: ${{ fromJson(needs.detect.outputs.envs) }}
     uses: ./.github/workflows/_tf-core.yml
     with:
-      environment: ${{ needs.setup.outputs.environment }}
-      region:      ${{ needs.setup.outputs.region }}
+      environment: ${{ matrix.env }}
+      region:      ${{ needs.detect.outputs.region }}
       action:      plan
     secrets: inherit

--- a/modules/compute-vm/main.tf
+++ b/modules/compute-vm/main.tf
@@ -34,6 +34,11 @@ resource "google_compute_instance" "api" {
   # Tags must match firewall target_tags
   tags = ["allow-iap-ssh", "sweptlock-backend"]
 
+  labels = {
+    managed-by  = "terraform"
+    environment = var.name_prefix
+  }
+
   boot_disk {
     initialize_params {
       image = "debian-cloud/debian-12"


### PR DESCRIPTION
Redesigns the Terraform CI/CD pipeline from branch-based to folder-based environment resolution.

## What changed

**Model shift:** environments are Terragrunt folders (), not git branches. Single  branch only.

**tf-plan.yml** — PR to main trigger, detects which env folders changed via , matrix-calls  per env. Shared changes (, ) plan all existing envs.

**tf-apply.yml** — push to main trigger, same detect logic, matrix-calls  per env. Each env is gated by its own GitHub Environment reviewers.

**_tf-core.yml** — dropped the separate  job and  env. The  job binding to  IS the approval gate.  resolved internally (single source of truth). Composite  action wired in.

**tf-setup composite action** — new at . Deduplicates Terraform + Terragrunt install + WIF auth between plan and apply jobs.

## Secrets model
- Repo secrets: , 
- Environment secret on :  + required reviewers

## To test
1. This PR triggers  — should detect  env and run parallel module plans
2. On merge,  fires — runs plan then waits for reviewer approval on  env

🤖 Generated with [Claude Code](https://claude.com/claude-code)