### PR TITLE
fix(ci): add pull-requests: write to tf-apply caller job

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -72,6 +72,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
tf-apply.yml was missing pull-requests: write, which _tf-core summarize job needs to post PR comments. Blocked the apply workflow from running after PR #2 merged.